### PR TITLE
Bump allocator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,18 @@ rust-version = "1.77"
 
 [patch.crates-io]
 rs-matter = { git = "https://github.com/project-chip/rs-matter" }
+#rs-matter = { git = "https://github.com/sysgrok/rs-matter", branch = "next" }
 #rs-matter = { path = "../rs-matter/rs-matter" }
 #edge-nal = { git = "https://github.com/sysgrok/edge-net" }
 #edge-nal-std = { git = "https://github.com/sysgrok/edge-net" }
 #edge-mdns = { git = "https://github.com/sysgrok/edge-net" }
+
+[profile.release]
+opt-level = "s"
+
+[profile.dev]
+debug = true
+opt-level = "z"
 
 [features]
 default = []

--- a/src/bump.rs
+++ b/src/bump.rs
@@ -1,0 +1,228 @@
+//! A super-simple bump allocator that allocates off from a fixed-size array.
+//!
+//! While dropping the `BumpBox` boxes will call the destructor of the contained object,
+//! the actual memory will be free only when the unsafe `reset` method is called.
+//!
+//! The primary use case of this allocator is reduction of Rust future sizes, due to
+//! `rustc` not being very intelligent w.r.t. stack usage in async functions.
+
+use core::marker::PhantomData;
+use core::mem::MaybeUninit;
+use core::pin::Pin;
+use core::ptr::NonNull;
+
+use embassy_sync::blocking_mutex::raw::RawMutex;
+use rs_matter::utils::cell::RefCell;
+use rs_matter::utils::init::{init, zeroed, Init};
+use rs_matter::utils::sync::blocking::Mutex;
+
+#[macro_export]
+macro_rules! alloc {
+    ($bump:expr, $obj:expr) => {
+        $bump.alloc($obj, concat!(file!(), ":", line!()))
+    };
+}
+
+#[macro_export]
+macro_rules! pin_alloc {
+    ($bump:expr, $obj:expr) => {
+        $bump.pin_alloc($obj, concat!(file!(), ":", line!()))
+    };
+}
+
+/// A bump allocator that uses a provided memory chunk
+pub struct Bump<const N: usize, M> {
+    inner: Mutex<M, RefCell<Inner<N>>>,
+}
+
+impl<const N: usize, M: RawMutex> Default for Bump<N, M> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<const N: usize, M: RawMutex> Bump<N, M> {
+    /// Create a new bump allocator
+    pub const fn new() -> Self {
+        Self {
+            inner: Mutex::new(RefCell::new(Inner::new())),
+        }
+    }
+
+    /// Return an initializer for a new bump allocator
+    pub fn init() -> impl Init<Self> {
+        init!(Self {
+            inner <- Mutex::init(RefCell::init(Inner::init())),
+        })
+    }
+
+    /// Reset the allocator, making all previously allocated memory available again.
+    ///
+    /// # Safety
+    /// This is unsafe because any previously allocated objects that are still in use
+    /// will get their memory corrupted and overwritten with new objects.
+    ///
+    /// Make sure that NO previously allocated objects are still in use
+    /// when calling this method.
+    pub unsafe fn reset(&self) {
+        self.inner.lock(|inner| {
+            let mut inner = inner.borrow_mut();
+
+            inner.offset = 0;
+        });
+    }
+
+    /// Allocate an object and return it pinned in a `Pin<BumpBox<T>>`
+    ///
+    /// # Arguments
+    /// - `object`: The object to allocate
+    /// - `location`: A string describing the location of the allocation, for logging purposes
+    ///
+    /// # Panics
+    /// This function will panic if there is not enough memory left in the bump allocator
+    pub fn pin_alloc<T>(&self, object: T, location: &str) -> Pin<BumpBox<'_, T>>
+    where
+        T: Sized,
+    {
+        let boxed = self.alloc(object, location);
+
+        boxed.into_pin()
+    }
+
+    /// Allocate an object and return it in a `BumpBox<T>`
+    ///
+    /// # Arguments
+    /// - `object`: The object to allocate
+    /// - `location`: A string describing the location of the allocation, for logging purposes
+    ///
+    /// # Panics
+    /// This function will panic if there is not enough memory left in the bump allocator
+    pub fn alloc<T>(&self, object: T, location: &str) -> BumpBox<'_, T>
+    where
+        T: Sized,
+    {
+        self.inner.lock(|inner| {
+            let mut inner = inner.borrow_mut();
+
+            let size = core::mem::size_of_val(&object);
+
+            let offset = inner.offset;
+            let memory = unsafe { inner.memory.assume_init_mut() };
+
+            info!(
+                "BUMP[{}]: {}b (U:{}b/F:{}b)",
+                location,
+                size,
+                offset,
+                memory.len() - offset
+            );
+
+            let remaining = &mut memory[offset..];
+            let remaining_len = remaining.len();
+
+            let (t_buf, r_buf) = align_min::<T>(remaining, 1);
+
+            // Safety: We just allocated the memory and it's properly aligned
+            let ptr = unsafe {
+                let ptr = t_buf.as_ptr() as *mut T;
+                ptr.write(object);
+
+                NonNull::new_unchecked(ptr)
+            };
+
+            inner.offset += remaining_len - r_buf.len();
+
+            BumpBox {
+                ptr,
+                _allocator: PhantomData,
+            }
+        })
+    }
+}
+
+/// A box-like container that uses bump allocation
+pub struct BumpBox<'a, T> {
+    ptr: NonNull<T>,
+    _allocator: core::marker::PhantomData<&'a ()>,
+}
+
+impl<T> BumpBox<'_, T> {
+    /// Convert the `BumpBox<T>` into a `Pin<BumpBox<T>>`
+    pub fn into_pin(self) -> Pin<Self> {
+        // It's not possible to move or replace the insides of a `Pin<Box<T>>`
+        // when `T: !Unpin`, so it's safe to pin it directly without any
+        // additional requirements.
+        unsafe { Pin::new_unchecked(self) }
+    }
+}
+
+impl<T> core::ops::Deref for BumpBox<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { self.ptr.as_ref() }
+    }
+}
+
+impl<T> core::ops::DerefMut for BumpBox<'_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { self.ptr.as_mut() }
+    }
+}
+
+impl<T> Unpin for BumpBox<'_, T> {}
+
+impl<T> Drop for BumpBox<'_, T> {
+    fn drop(&mut self) {
+        // Safety: The pointer is valid and we own the data
+        unsafe {
+            self.ptr.as_ptr().drop_in_place();
+        }
+    }
+}
+
+struct Inner<const N: usize> {
+    memory: MaybeUninit<[u8; N]>,
+    offset: usize,
+}
+
+impl<const N: usize> Inner<N> {
+    const fn new() -> Self {
+        Self {
+            memory: MaybeUninit::uninit(),
+            offset: 0,
+        }
+    }
+
+    fn init() -> impl Init<Self> {
+        init!(Self {
+            memory <- zeroed(),
+            offset: 0,
+        })
+    }
+}
+
+fn align_min<T>(buf: &mut [u8], count: usize) -> (&mut [MaybeUninit<T>], &mut [u8]) {
+    if count == 0 || core::mem::size_of::<T>() == 0 {
+        return (&mut [], buf);
+    }
+
+    let (t_leading_buf0, t_buf, _) = unsafe { buf.align_to_mut::<MaybeUninit<T>>() };
+    if t_buf.len() < count {
+        panic!("Out of bump memory");
+    }
+
+    // Shrink `t_buf` to the number of requested items (count)
+    let t_buf = &mut t_buf[..count];
+    let t_leading_buf0_len = t_leading_buf0.len();
+    let t_buf_size = core::mem::size_of_val(t_buf);
+
+    let (buf0, remaining_buf) = buf.split_at_mut(t_leading_buf0_len + t_buf_size);
+
+    let (t_leading_buf, t_buf, t_remaining_buf) = unsafe { buf0.align_to_mut::<MaybeUninit<T>>() };
+    assert_eq!(t_leading_buf0_len, t_leading_buf.len());
+    assert_eq!(t_buf.len(), count);
+    assert!(t_remaining_buf.is_empty());
+
+    (t_buf, remaining_buf)
+}

--- a/src/wireless/gatt.rs
+++ b/src/wireless/gatt.rs
@@ -1,3 +1,5 @@
+use core::future::Future;
+
 use rs_matter::error::Error;
 use rs_matter::transport::network::btp::GattPeripheral;
 
@@ -16,11 +18,11 @@ impl<T> GattTask for &mut T
 where
     T: GattTask,
 {
-    async fn run<P>(&mut self, peripheral: P) -> Result<(), Error>
+    fn run<P>(&mut self, peripheral: P) -> impl Future<Output = Result<(), Error>>
     where
         P: GattPeripheral,
     {
-        T::run(*self, peripheral).await
+        T::run(*self, peripheral)
     }
 }
 
@@ -38,11 +40,11 @@ impl<T> Gatt for &mut T
 where
     T: Gatt,
 {
-    async fn run<A>(&mut self, task: A) -> Result<(), Error>
+    fn run<A>(&mut self, task: A) -> impl Future<Output = Result<(), Error>>
     where
         A: GattTask,
     {
-        T::run(self, task).await
+        T::run(self, task)
     }
 }
 

--- a/src/wireless/thread.rs
+++ b/src/wireless/thread.rs
@@ -1,3 +1,4 @@
+use core::future::Future;
 use core::pin::pin;
 
 use embassy_futures::select::{select, select3, select4};
@@ -25,14 +26,15 @@ use crate::nal::NetStack;
 use crate::network::Embedding;
 use crate::persist::{KvBlobStore, SharedKvBlobStore};
 use crate::wireless::{GattTask, MatterStackWirelessTask};
-use crate::UserTask;
+use crate::{pin_alloc, UserTask};
 
 use super::{Gatt, PreexistingWireless, WirelessMatterStack};
 
 /// A type alias for a Matter stack running over Thread (and BLE, during commissioning).
-pub type ThreadMatterStack<'a, M, E = ()> = WirelessMatterStack<'a, M, wireless::Thread, E>;
+pub type ThreadMatterStack<'a, const B: usize, M, E = ()> =
+    WirelessMatterStack<'a, B, M, wireless::Thread, E>;
 
-impl<M, E> WirelessMatterStack<'_, M, wireless::Thread, E>
+impl<const B: usize, M, E> WirelessMatterStack<'_, B, M, wireless::Thread, E>
 where
     M: RawMutex + Send + Sync + 'static,
     E: Embedding + 'static,
@@ -88,7 +90,7 @@ where
     /// - `user` - a user-provided future that will be polled only when the netif interface is up
     pub async fn run_coex<W, S, H, U>(
         &'static self,
-        thread: W,
+        mut thread: W,
         store: &SharedKvBlobStore<'_, S>,
         handler: H,
         user: U,
@@ -99,7 +101,15 @@ where
         H: AsyncHandler + AsyncMetadata,
         U: UserTask,
     {
-        info!("Matter Stack memory: {}B", core::mem::size_of_val(self));
+        let _lock = self.run_lock.lock().await;
+
+        info!("Matter Stack memory: {}b", core::mem::size_of_val(self));
+
+        // Since this is the last code executed in the method, resetting the allocator should be safe
+        // because all boxes returned by it should be dropped by then
+        let _defer = scopeguard::guard((), |_| unsafe {
+            self.bump.reset();
+        });
 
         let persist = self.create_persist(store);
 
@@ -107,8 +117,8 @@ where
 
         self.matter().reset_transport()?;
 
-        let mut net_task = pin!(self.run_thread_coex(thread, handler, user));
-        let mut persist_task = pin!(self.run_psm(&persist));
+        let mut net_task = pin_alloc!(self.bump, self.run_thread_coex(&mut thread, handler, user));
+        let mut persist_task = pin_alloc!(self.bump, self.run_psm(&persist));
 
         select(&mut net_task, &mut persist_task).coalesce().await
     }
@@ -133,7 +143,15 @@ where
         H: AsyncHandler + AsyncMetadata,
         U: UserTask,
     {
-        info!("Matter Stack memory: {}B", core::mem::size_of_val(self));
+        let _lock = self.run_lock.lock().await;
+
+        info!("Matter Stack memory: {}b", core::mem::size_of_val(self));
+
+        // Since this is the last code executed in the method, resetting the allocator should be safe
+        // because all boxes returned by it should be dropped by then
+        let _defer = scopeguard::guard((), |_| unsafe {
+            self.bump.reset();
+        });
 
         let persist = self.create_persist(store);
 
@@ -141,26 +159,24 @@ where
 
         self.matter().reset_transport()?;
 
-        let mut net_task = pin!(self.run_thread(thread, handler, user));
-        let mut persist_task = pin!(self.run_psm(&persist));
+        let mut net_task = pin_alloc!(self.bump, self.run_thread(thread, handler, user));
+        let mut persist_task = pin_alloc!(self.bump, self.run_psm(&persist));
 
         select(&mut net_task, &mut persist_task).coalesce().await
     }
 
-    async fn run_thread_coex<W, H, U>(
+    fn run_thread_coex<'t, W, H, U>(
         &'static self,
-        mut thread: W,
+        thread: &'t mut W,
         handler: H,
         user: U,
-    ) -> Result<(), Error>
+    ) -> impl Future<Output = Result<(), Error>> + 't
     where
-        W: ThreadCoex,
-        H: AsyncHandler + AsyncMetadata,
-        U: UserTask,
+        W: ThreadCoex + 't,
+        H: AsyncHandler + AsyncMetadata + 't,
+        U: UserTask + 't,
     {
-        thread
-            .run(MatterStackWirelessTask(self, handler, user))
-            .await
+        thread.run(MatterStackWirelessTask(self, handler, user))
     }
 
     async fn run_thread<W, H, U>(
@@ -253,20 +269,20 @@ impl<T> ThreadTask for &mut T
 where
     T: ThreadTask,
 {
-    async fn run<S, N, C, M>(
+    fn run<S, N, C, M>(
         &mut self,
         net_stack: S,
         netif: N,
         net_ctl: C,
         mdns: M,
-    ) -> Result<(), Error>
+    ) -> impl Future<Output = Result<(), Error>>
     where
         S: NetStack,
         N: NetifDiag + NetChangeNotif,
         C: NetCtl + ThreadDiag + NetChangeNotif,
         M: Mdns,
     {
-        T::run(*self, net_stack, netif, net_ctl, mdns).await
+        T::run(*self, net_stack, netif, net_ctl, mdns)
     }
 }
 
@@ -283,11 +299,11 @@ impl<T> Thread for &mut T
 where
     T: Thread,
 {
-    async fn run<A>(&mut self, task: A) -> Result<(), Error>
+    fn run<A>(&mut self, task: A) -> impl Future<Output = Result<(), Error>>
     where
         A: ThreadTask,
     {
-        T::run(self, task).await
+        T::run(self, task)
     }
 }
 
@@ -317,14 +333,14 @@ impl<T> ThreadCoexTask for &mut T
 where
     T: ThreadCoexTask,
 {
-    async fn run<S, N, C, M, G>(
+    fn run<S, N, C, M, G>(
         &mut self,
         net_stack: S,
         netif: N,
         net_ctl: C,
         mdns: M,
         gatt: G,
-    ) -> Result<(), Error>
+    ) -> impl Future<Output = Result<(), Error>>
     where
         S: NetStack,
         N: NetifDiag + NetChangeNotif,
@@ -332,7 +348,7 @@ where
         M: Mdns,
         G: GattPeripheral,
     {
-        T::run(*self, net_stack, netif, net_ctl, mdns, gatt).await
+        T::run(*self, net_stack, netif, net_ctl, mdns, gatt)
     }
 }
 
@@ -353,11 +369,11 @@ impl<T> ThreadCoex for &mut T
 where
     T: ThreadCoex,
 {
-    async fn run<A>(&mut self, task: A) -> Result<(), Error>
+    fn run<A>(&mut self, task: A) -> impl Future<Output = Result<(), Error>>
     where
         A: ThreadCoexTask,
     {
-        T::run(self, task).await
+        T::run(self, task)
     }
 }
 
@@ -400,7 +416,8 @@ where
     }
 }
 
-impl<M, E, H, X> GattTask for MatterStackWirelessTask<'static, M, wireless::Thread, E, H, X>
+impl<const B: usize, M, E, H, X> GattTask
+    for MatterStackWirelessTask<'static, B, M, wireless::Thread, E, H, X>
 where
     M: RawMutex + Send + Sync + 'static,
     E: Embedding + 'static,
@@ -424,7 +441,8 @@ where
     }
 }
 
-impl<M, E, H, X> ThreadTask for MatterStackWirelessTask<'static, M, wireless::Thread, E, H, X>
+impl<const B: usize, M, E, H, X> ThreadTask
+    for MatterStackWirelessTask<'static, B, M, wireless::Thread, E, H, X>
 where
     M: RawMutex + Send + Sync + 'static,
     E: Embedding + 'static,
@@ -454,11 +472,12 @@ where
 
         let mut net_task = pin!(stack.run_oper_net(
             &net_stack,
-            &netif,
-            &mut mdns,
             core::future::pending(),
             Option::<(NoNetwork, NoNetwork)>::None
         ));
+
+        let mut mdns_task = pin!(stack.run_oper_netif_mdns(&net_stack, &netif, &mut mdns));
+
         let mut mgr_task = pin!(mgr.run());
 
         let net_ctl_s = NetCtlWithStatusImpl::new(&self.0.network.net_state, &net_ctl);
@@ -466,22 +485,24 @@ where
         let handler = self
             .0
             .root_handler(&(), &netif, &net_ctl_s, &false, &self.1);
+
         let mut handler_task = pin!(self.0.run_handler((&self.1, handler)));
 
         let mut user_task = pin!(self.2.run(&net_stack, &netif));
 
         select4(
             &mut net_task,
+            &mut mdns_task,
             &mut mgr_task,
-            &mut handler_task,
-            &mut user_task,
+            select(&mut handler_task, &mut user_task).coalesce(),
         )
         .coalesce()
         .await
     }
 }
 
-impl<M, E, H, X> ThreadCoexTask for MatterStackWirelessTask<'static, M, wireless::Thread, E, H, X>
+impl<const B: usize, M, E, H, X> ThreadCoexTask
+    for MatterStackWirelessTask<'static, B, M, wireless::Thread, E, H, X>
 where
     M: RawMutex + Send + Sync + 'static,
     E: Embedding + 'static,
@@ -506,16 +527,19 @@ where
         info!("Thread and BLE drivers started");
 
         let stack = &mut self.0;
+        let bump = &stack.bump;
 
-        let mut net_task =
-            pin!(stack.run_net_coex(&net_stack, &netif, &net_ctl, &mut mdns, &mut gatt));
+        let mut net_task = pin_alloc!(
+            bump,
+            stack.run_net_coex(&net_stack, &netif, &net_ctl, &mut mdns, &mut gatt)
+        );
 
         let net_ctl_s = NetCtlWithStatusImpl::new(&self.0.network.net_state, &net_ctl);
 
         let handler = self.0.root_handler(&(), &netif, &net_ctl_s, &true, &self.1);
-        let mut handler_task = pin!(self.0.run_handler((&self.1, handler)));
+        let mut handler_task = pin_alloc!(bump, self.0.run_handler_with_bump((&self.1, handler)));
 
-        let mut user_task = pin!(self.2.run(&net_stack, &netif));
+        let mut user_task = pin_alloc!(bump, self.2.run(&net_stack, &netif));
 
         select3(&mut net_task, &mut handler_task, &mut user_task)
             .coalesce()


### PR DESCRIPTION
Implements a tiny `Bump` allocator, which is used to hold the memory for large(r) futures.

The bump allocator is used in the `run` / `run_coex` methods of the Matter Stacks, and holds all futures which are created and are _valid for the whole duration of the `run` / `run_coex` method_. Since the lifetime of those futures coincides with the lifetime of the `run` / `run_coex` method, these can be created once, moved in the bump memory and then - upon exit from the `run` / `run_coex` method - their memory can be reclaimed.

This helps tremendously in mitigating the devastating effect on the MCU stack of 
(a) moving those those (large) futures around (as they are now boxed inside a `BumpBox` similar to as if using a regular heap allocator) 
and 
(b) addressing the current sub-optimal memory consumption for the futures' state machines as generated by rustc's async/await syntax, in that if the inner futures of a large future are boxed (and are thus mere pointers), the memory inefficiencies inside the outer future are less painful.
