### PR TITLE
Add tests and change bump allocator implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          components: rustfmt, clippy, rust-src, miri
+          components: rustfmt, clippy, rust-src
 
       - name: Install libdbus
         run: sudo apt-get install -y libdbus-1-dev
@@ -56,14 +56,6 @@ jobs:
         if: matrix.features == 'std'
         run: cargo test --features ${{matrix.features}}
 
-      - name: Miri Setup
-        if: matrix.features == 'std'
-        run: cargo miri setup
-
-      - name: Miri Test
-        if: matrix.features == 'std'
-        run: cargo miri test --features ${{matrix.features}}
-
       - name: Examples
         if: matrix.features == 'os'
         run: cargo build --release --examples --features ${{matrix.features}},nix,log,examples
@@ -91,3 +83,32 @@ jobs:
         if: ${{ !env.ACT && matrix.features == 'os' }}
         with:
           platform-name: cross-platform
+
+  run_miri:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        features: ['std']
+
+    steps:
+      - name: Rust
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: miri
+
+      - name: Install libdbus
+        run: sudo apt-get install -y libdbus-1-dev
+
+      - name: Install libavahi-client
+        run: sudo apt-get install -y libavahi-client-dev
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Miri Setup
+        if: matrix.features == 'std'
+        run: cargo miri setup
+
+      - name: Miri Test
+        if: matrix.features == 'std'
+        run: cargo miri test --features ${{matrix.features}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          components: rustfmt, clippy, rust-src
+          components: rustfmt, clippy, rust-src, miri
 
       - name: Install libdbus
         run: sudo apt-get install -y libdbus-1-dev
@@ -51,6 +51,18 @@ jobs:
 
       - name: Build
         run: cargo build --no-default-features --features ${{matrix.features}}
+
+      - name: Test
+        if: matrix.features == 'std'
+        run: cargo test --features ${{matrix.features}}
+
+      - name: Miri Setup
+        if: matrix.features == 'std'
+        run: cargo miri setup
+
+      - name: Miri Test
+        if: matrix.features == 'std'
+        run: cargo miri test --features ${{matrix.features}}
 
       - name: Examples
         if: matrix.features == 'os'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,7 +163,7 @@ rustcrypto = ["rs-matter/rustcrypto"]
 os = ["backtrace", "rs-matter/os", "rustcrypto", "embassy-time/std"]
 backtrace = ["std", "rs-matter/backtrace"]
 async-io-mini = ["std", "edge-nal-std/async-io-mini"]
-std = ["alloc", "rs-matter/std", "edge-nal-std"]
+std = ["alloc", "rs-matter/std", "edge-nal-std", "critical-section/std"]
 alloc = ["embedded-svc/alloc"]
 examples = ["log", "os", "nix", "embassy-time-queue-utils/generic-queue-64", "zeroconf"]
 
@@ -191,6 +191,7 @@ bitflags = "2"
 nix = { version = "0.27", features = ["net"], optional = true }
 
 [dev-dependencies]
+critical-section = "1.0"
 static_cell = "2.1"
 futures-lite = "1"
 async-compat = "0.2"


### PR DESCRIPTION
While looking into #24, I noticed some pieces of code in the bump allocator that looked wrong.

What has been changed?
- The new code does not assume that the memory is initialized, before it was written to (I think the old one was okay too, but not sure)
- Miri found this in the original code `let ptr = t_buf.as_ptr() as *mut T;` where a `*const T` is cast to `*mut T`
- The old implementation took a reference to the memory and implicitly extended it to the lifetime of `&self` by the use of pointers, I made this explicit through references. Note that this might have been a wrong decision, miri isn't happy with my current impl (see pending CI), because of overlapping borrows. Will have to check if the original code had that issue too.
- Added tests and updated the CI to run them
- Added miri in CI to catch undefined behavior. Given that this crate can run on a regular host like linux, it seems sensible to use miri.