### PR TITLE
Decrease log level of bump

### DIFF
--- a/src/bump.rs
+++ b/src/bump.rs
@@ -109,7 +109,7 @@ impl<const N: usize, M: RawMutex> Bump<N, M> {
             let offset = inner.offset;
             let memory = unsafe { inner.memory.assume_init_mut() };
 
-            info!(
+            debug!(
                 "BUMP[{}]: {}b (U:{}b/F:{}b)",
                 location,
                 size,


### PR DESCRIPTION
This message is generally less important during regular execution of a program and we also include the build location.