### PR TITLE
Update to latest rs-matter

### DIFF
--- a/src/eth.rs
+++ b/src/eth.rs
@@ -9,7 +9,7 @@ use rs_matter::dm::clusters::gen_diag::{GenDiag, NetifDiag};
 use rs_matter::dm::clusters::net_comm::DummyNetworkAccess;
 use rs_matter::dm::endpoints::{with_eth_sys, EthSysHandler};
 use rs_matter::dm::networks::NetChangeNotif;
-use rs_matter::dm::{AsyncHandler, AsyncMetadata, Endpoint};
+use rs_matter::dm::{DataModelHandler, Endpoint};
 use rs_matter::error::Error;
 use rs_matter::pairing::DiscoveryCapabilities;
 use rs_matter::persist::{KvBlobStore, KvBlobStoreAccess};
@@ -242,7 +242,7 @@ where
         N: NetifDiag + NetChangeNotif + 't,
         M: Mdns + 't,
         C: Crypto + 't,
-        H: AsyncHandler + AsyncMetadata + 't,
+        H: DataModelHandler + 't,
         S: KvBlobStoreAccess + 't,
         X: UserTask + 't,
     {
@@ -274,7 +274,7 @@ where
     where
         N: Ethernet,
         C: Crypto,
-        H: AsyncHandler + AsyncMetadata,
+        H: DataModelHandler,
         S: KvBlobStoreAccess,
         X: UserTask,
     {
@@ -309,7 +309,7 @@ where
     where
         N: Ethernet + 't,
         C: Crypto + 't,
-        H: AsyncHandler + AsyncMetadata + 't,
+        H: DataModelHandler + 't,
         S: KvBlobStoreAccess + 't,
         X: UserTask + 't,
     {
@@ -330,7 +330,7 @@ struct MatterStackEthernetTask<'a, const B: usize, E, C, H, S, X>
 where
     E: Embedding,
     C: Crypto,
-    H: AsyncMetadata + AsyncHandler,
+    H: DataModelHandler,
     S: KvBlobStoreAccess,
     X: UserTask,
 {
@@ -345,7 +345,7 @@ impl<const B: usize, E, C, H, S, X> EthernetTask for MatterStackEthernetTask<'_,
 where
     E: Embedding,
     C: Crypto,
-    H: AsyncMetadata + AsyncHandler,
+    H: DataModelHandler,
     S: KvBlobStoreAccess,
     X: UserTask,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ use cfg_if::cfg_if;
 
 use edge_nal::{UdpBind, UdpSplit};
 
-use embassy_futures::select::{select, select3, select_slice};
+use embassy_futures::select::{select, select_slice};
 use embassy_time::Duration;
 
 use rs_matter::crypto::Crypto;
@@ -31,8 +31,7 @@ use rs_matter::dm::events::Events;
 use rs_matter::dm::networks::NetChangeNotif;
 use rs_matter::dm::subscriptions::Subscriptions;
 use rs_matter::dm::{
-    AsyncHandler, AsyncMetadata, AttrChangeNotifier, AttrId, ClusterId, DataModel, EndptId,
-    IMBuffer,
+    AttrChangeNotifier, AttrId, ClusterId, DataModel, DataModelHandler, EndptId, IMBuffer,
 };
 use rs_matter::error::{Error, ErrorCode};
 use rs_matter::pairing::qr::QrTextType;
@@ -678,7 +677,7 @@ where
     ) -> MatterStackDataModel<'_, C, H, S, W>
     where
         C: Crypto,
-        H: AsyncHandler + AsyncMetadata,
+        H: DataModelHandler,
         S: KvBlobStoreAccess,
         W: NetworksAccess,
     {
@@ -700,7 +699,7 @@ where
     ) -> Result<(), Error>
     where
         C: Crypto,
-        H: AsyncHandler + AsyncMetadata,
+        H: DataModelHandler,
         S: KvBlobStoreAccess,
         W: NetworksAccess,
     {
@@ -720,7 +719,7 @@ where
     ) -> Result<(), Error>
     where
         C: Crypto,
-        H: AsyncHandler + AsyncMetadata,
+        H: DataModelHandler,
         S: KvBlobStoreAccess,
         W: NetworksAccess,
     {
@@ -740,7 +739,7 @@ where
     ) -> Result<(), Error>
     where
         C: Crypto,
-        H: AsyncHandler + AsyncMetadata,
+        H: DataModelHandler,
         S: KvBlobStoreAccess,
         W: NetworksAccess,
     {
@@ -759,7 +758,7 @@ where
     ) -> Result<(), Error>
     where
         C: Crypto,
-        H: AsyncHandler + AsyncMetadata,
+        H: DataModelHandler,
         S: KvBlobStoreAccess,
         W: NetworksAccess,
     {
@@ -773,9 +772,8 @@ where
             self.bump,
             self.run_one_responder_with_bump::<MAX_BUSY_RESPONDERS, _>(responder.busy_responder())
         );
-        let mut sub = pin_alloc!(self.bump, responder.process_subscriptions());
 
-        select3(&mut actual, &mut busy, &mut sub).coalesce().await
+        select(&mut actual, &mut busy).coalesce().await
     }
 
     /// Run a responder with Q handlers using the provided bump allocator.

--- a/src/wireless/thread.rs
+++ b/src/wireless/thread.rs
@@ -6,6 +6,7 @@ use embassy_futures::select::{select, select3, select4};
 use rs_matter::crypto::{Crypto, RngCore};
 use rs_matter::dm::clusters::gen_comm::CommPolicy;
 use rs_matter::dm::clusters::gen_diag::GenDiag;
+use rs_matter::dm::clusters::gen_diag::NetifDiag;
 use rs_matter::dm::clusters::net_comm::{NetCtl, NetCtlStatus, NetworkType};
 use rs_matter::dm::clusters::thread_diag::ThreadDiag;
 use rs_matter::dm::endpoints::{with_thread_sys, ThreadSysHandler};
@@ -13,8 +14,7 @@ use rs_matter::dm::networks::wireless::{
     self, NetCtlWithStatusImpl, NoopWirelessNetCtl, WirelessMgr,
 };
 use rs_matter::dm::networks::NetChangeNotif;
-use rs_matter::dm::{clusters::gen_diag::NetifDiag, AsyncHandler};
-use rs_matter::dm::{AsyncMetadata, Endpoint};
+use rs_matter::dm::{DataModelHandler, Endpoint};
 use rs_matter::error::Error;
 use rs_matter::persist::KvBlobStoreAccess;
 use rs_matter::root_endpoint;
@@ -69,7 +69,7 @@ where
         D: Mdns + 't,
         G: GattPeripheral + 't,
         C: Crypto + 't,
-        H: AsyncHandler + AsyncMetadata + 't,
+        H: DataModelHandler + 't,
         S: KvBlobStoreAccess + 't,
         X: UserTask + 't,
     {
@@ -101,7 +101,7 @@ where
     where
         W: ThreadCoex,
         C: Crypto,
-        H: AsyncHandler + AsyncMetadata,
+        H: DataModelHandler,
         S: KvBlobStoreAccess,
         U: UserTask,
     {
@@ -145,7 +145,7 @@ where
         W: Thread + Gatt,
         S: KvBlobStoreAccess,
         C: Crypto,
-        H: AsyncHandler + AsyncMetadata,
+        H: DataModelHandler,
         U: UserTask,
     {
         let _lock = self.run_lock.lock().await;
@@ -179,7 +179,7 @@ where
     where
         W: ThreadCoex + 't,
         C: Crypto + 't,
-        H: AsyncHandler + AsyncMetadata + 't,
+        H: DataModelHandler + 't,
         S: KvBlobStoreAccess + 't,
         U: UserTask + 't,
     {
@@ -203,7 +203,7 @@ where
     where
         W: Thread + Gatt,
         C: Crypto,
-        H: AsyncHandler + AsyncMetadata,
+        H: DataModelHandler,
         S: KvBlobStoreAccess,
         U: UserTask,
     {
@@ -239,7 +239,7 @@ where
                     &self.network().networks,
                 );
 
-                self.matter().close_comm_window(dm.change_notify())?;
+                dm.close_comm_window()?;
             }
 
             Thread::run(
@@ -464,7 +464,7 @@ impl<'a, const B: usize, E, C, H, S, X> GattTask
 where
     E: Embedding,
     C: Crypto,
-    H: AsyncMetadata + AsyncHandler,
+    H: DataModelHandler,
     S: KvBlobStoreAccess,
 {
     async fn run<P>(&mut self, peripheral: P) -> Result<(), Error>
@@ -504,7 +504,7 @@ impl<'a, const B: usize, E, C, H, S, X> ThreadTask
 where
     E: Embedding,
     C: Crypto,
-    H: AsyncMetadata + AsyncHandler,
+    H: DataModelHandler,
     S: KvBlobStoreAccess,
     X: UserTask,
 {
@@ -579,7 +579,7 @@ impl<'a, const B: usize, E, C, H, S, X> ThreadCoexTask
 where
     E: Embedding,
     C: Crypto,
-    H: AsyncMetadata + AsyncHandler,
+    H: DataModelHandler,
     S: KvBlobStoreAccess,
     X: UserTask,
 {

--- a/src/wireless/wifi.rs
+++ b/src/wireless/wifi.rs
@@ -6,6 +6,7 @@ use embassy_futures::select::{select, select3, select4};
 use rs_matter::crypto::{Crypto, RngCore};
 use rs_matter::dm::clusters::gen_comm::CommPolicy;
 use rs_matter::dm::clusters::gen_diag::GenDiag;
+use rs_matter::dm::clusters::gen_diag::NetifDiag;
 use rs_matter::dm::clusters::net_comm::{NetCtl, NetCtlStatus, NetworkType};
 use rs_matter::dm::clusters::wifi_diag::WifiDiag;
 use rs_matter::dm::endpoints::{with_wifi_sys, WifiSysHandler};
@@ -13,8 +14,7 @@ use rs_matter::dm::networks::wireless::{
     self, NetCtlWithStatusImpl, NoopWirelessNetCtl, WirelessMgr,
 };
 use rs_matter::dm::networks::NetChangeNotif;
-use rs_matter::dm::{clusters::gen_diag::NetifDiag, AsyncHandler};
-use rs_matter::dm::{AsyncMetadata, Endpoint};
+use rs_matter::dm::{DataModelHandler, Endpoint};
 use rs_matter::error::Error;
 use rs_matter::persist::KvBlobStoreAccess;
 use rs_matter::root_endpoint;
@@ -69,7 +69,7 @@ where
         D: Mdns + 't,
         G: GattPeripheral + 't,
         C: Crypto + 't,
-        H: AsyncHandler + AsyncMetadata + 't,
+        H: DataModelHandler + 't,
         S: KvBlobStoreAccess + 't,
         X: UserTask + 't,
     {
@@ -101,7 +101,7 @@ where
     where
         W: WifiCoex,
         C: Crypto,
-        H: AsyncHandler + AsyncMetadata,
+        H: DataModelHandler,
         S: KvBlobStoreAccess,
         U: UserTask,
     {
@@ -144,7 +144,7 @@ where
     where
         W: Wifi + Gatt,
         C: Crypto,
-        H: AsyncHandler + AsyncMetadata,
+        H: DataModelHandler,
         S: KvBlobStoreAccess,
         U: UserTask,
     {
@@ -176,7 +176,7 @@ where
     where
         W: WifiCoex + 't,
         C: Crypto + 't,
-        H: AsyncHandler + AsyncMetadata + 't,
+        H: DataModelHandler + 't,
         S: KvBlobStoreAccess + 't,
         U: UserTask + 't,
     {
@@ -200,7 +200,7 @@ where
     where
         W: Wifi + Gatt,
         C: Crypto,
-        H: AsyncHandler + AsyncMetadata,
+        H: DataModelHandler,
         S: KvBlobStoreAccess,
         U: UserTask,
     {
@@ -224,7 +224,7 @@ where
             if commissioned {
                 let net_ctl = NetCtlWithStatusImpl::new(
                     &self.network.net_state,
-                    NoopWirelessNetCtl::new(NetworkType::Thread),
+                    NoopWirelessNetCtl::new(NetworkType::Wifi),
                 );
 
                 let root_handler =
@@ -236,7 +236,7 @@ where
                     &self.network().networks,
                 );
 
-                self.matter().close_comm_window(dm.change_notify())?;
+                dm.close_comm_window()?;
             }
 
             Wifi::run(
@@ -461,7 +461,7 @@ impl<'a, const B: usize, E, C, H, S, U> GattTask
 where
     E: Embedding,
     C: Crypto,
-    H: AsyncMetadata + AsyncHandler,
+    H: DataModelHandler,
     S: KvBlobStoreAccess,
 {
     async fn run<P>(&mut self, peripheral: P) -> Result<(), Error>
@@ -501,7 +501,7 @@ impl<'a, const B: usize, E, C, H, S, X> WifiTask
 where
     E: Embedding,
     C: Crypto,
-    H: AsyncMetadata + AsyncHandler,
+    H: DataModelHandler,
     S: KvBlobStoreAccess,
     X: UserTask,
 {
@@ -576,7 +576,7 @@ impl<'a, const B: usize, E, C, H, S, X> WifiCoexTask
 where
     E: Embedding,
     C: Crypto,
-    H: AsyncMetadata + AsyncHandler,
+    H: DataModelHandler,
     S: KvBlobStoreAccess,
     X: UserTask,
 {


### PR DESCRIPTION
Upstream rs-matter will [soon change how the Node metadata is locked when doing path expansion](https://github.com/project-chip/rs-matter/pull/435), which is a small yet breaking API change that affects downstream.

Prepare a fix for that.