### PR TITLE
docs: surface the events-ringbuf-size-0 default in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ The [`rs-matter-embassy`](https://github.com/ivmarkov/rs-matter-embassy) crate p
 
 The [`esp-idf-matter`](https://github.com/ivmarkov/esp-idf-matter) crate provides implementations for `KvBlobStore`, `NetifDiag`, `GattPeripheral` and others for the [ESP-IDF SDK](https://github.com/esp-rs/esp-idf-svc).
 
+## Event ring-buffer
+
+The Matter event subsystem is gated by mutually-exclusive Cargo features `events-ringbuf-size-{0,64,128,256,512,1024,2048}`. The size sets the per-priority buffer in [`Events<N>`](https://github.com/project-chip/rs-matter/blob/main/rs-matter/src/dm/events.rs).
+
+**The default is `events-ringbuf-size-0`**, which disables event emission: `emit_event()` returns `Ok` and the device-side event counter still advances, but no bytes are stored and controllers never see any events. Devices that emit events &mdash; including any Generic Switch (0x000F), and any device required to send `BasicInformation::StartUp` on boot (Matter Core &sect;11.1.6) &mdash; must enable a non-zero size, e.g.:
+
+```toml
+rs-matter-stack = { ..., features = ["events-ringbuf-size-512"] }
+```
+
+Sizing rule of thumb: 256 fits a few back-to-back events; 512 covers a burst of multi-press / scene activation; 1024+ if a chatty handler is expected.
+
 ## Example
 
 (See also [All examples](#all-examples))


### PR DESCRIPTION
Hi again :)

Same gotcha I just pinged you about on `esp-idf-matter` (sysgrok/esp-idf-matter#28), but documented on the side that actually owns the features.

Burned a few hours debugging a Matter Generic Switch where `emit_event` returned `Ok` and `max_seen_event_number` advanced on every button press, yet the controller never received an event. Walking back through `rs-matter`'s `EventWriter::write`:

    if N == 0 { return Ok(()); }

…lined up with the `events-ringbuf-size-0` default. The \`Cargo.toml\` inline comment is accurate but invisible to anyone reading the README, and the failure mode is "everything looks fine, controller just sees nothing" — not the easiest to track down.

Adds a short README section with the bit, the fix, and a sizing note. Wording is just a sketch.

An alternative (if it makes sense) would be to change the default to a non-zero size like 256 or 512, so devices that emit any event — today that's any cluster handler calling \`emit_for\`, plus rs-matter's own \`AccessControlEntryChanged\` event on ACL writes during commissioning — work out of the box, and only users explicitly disabling events would opt into 0.