### PR TITLE
persist EventNumber across restarts (Matter Core §7.14.1.1)

### DIFF
--- a/src/eth.rs
+++ b/src/eth.rs
@@ -175,25 +175,37 @@ where
     }
 
     /// Reset the Matter instance to the factory defaults by removing all fabrics and basic info settings
-    pub async fn reset<S>(&mut self, kv: S) -> Result<(), Error>
+    pub async fn reset<S>(&mut self, mut kv: S) -> Result<(), Error>
     where
         S: KvBlobStore,
     {
         let mut buf = unwrap!(self.store_buf.try_get());
         let buf = buf.borrow_mut();
 
-        self.matter.reset_persist(kv, buf).await
+        self.matter.reset_persist(&mut kv, buf).await?;
+
+        // Reset the events counter so we don't carry a stale watermark
+        // across a factory reset (Matter Core spec R1.5.1, §7.14.1.1).
+        self.events.reset_persist(kv, buf).await?;
+
+        Ok(())
     }
 
     /// Load the persisted state from the provided `KvBlobStore` implementation.
-    pub async fn load<S>(&mut self, kv: S) -> Result<(), Error>
+    pub async fn load<S>(&mut self, mut kv: S) -> Result<(), Error>
     where
         S: KvBlobStore,
     {
         let mut buf = unwrap!(self.store_buf.try_get());
         let buf = buf.borrow_mut();
 
-        self.matter.load_persist(kv, buf).await
+        self.matter.load_persist(&mut kv, buf).await?;
+
+        // Restore the events counter so EventNumber stays monotonic across
+        // restarts (Matter Core spec R1.5.1, §7.14.1.1 SHALL).
+        self.events.load_persist(kv, buf).await?;
+
+        Ok(())
     }
 
     /// Run the startup sequence of the stack, which includes loading the persisted state

--- a/src/wireless.rs
+++ b/src/wireless.rs
@@ -154,6 +154,10 @@ where
 
         self.matter.reset_persist(&mut kv, buf).await?;
 
+        // Reset the events counter so we don't carry a stale watermark
+        // across a factory reset (Matter Core spec R1.5.1, §7.14.1.1).
+        self.events.reset_persist(&mut kv, buf).await?;
+
         self.network
             .networks
             .get_mut()
@@ -171,6 +175,10 @@ where
         let buf = buf.borrow_mut();
 
         self.matter.load_persist(&mut kv, buf).await?;
+
+        // Restore the events counter so EventNumber stays monotonic across
+        // restarts (Matter Core spec R1.5.1, §7.14.1.1 SHALL).
+        self.events.load_persist(&mut kv, buf).await?;
 
         self.network
             .networks


### PR DESCRIPTION
Fixes #38.

Wires `Events::{load,reset}_persist` into `MatterStack::{load,reset}`
for both the Eth and Wireless variants, so the EventNumber counter is
restored on boot and cleared on factory reset alongside the existing
fabrics / basic-info persistence.

Without this, the counter restarts at 1 after every reboot.
Subscribers that cached an `EventMin` watermark from the previous
session then filter out the early events of the new session — on a
GenericSwitch endpoint this manifests as button presses silently
dropped until the device catches up past the stored watermark.

rs-matter already implements the `+EVENT_NUMBER_EPOCH_SIZE` (10000)
bump-on-load strategy and exposes `Events::{load,reset}_persist`;
this PR is the missing call site in rs-matter-stack.

## Verification

ESP32-C6 Thread device against Home Assistant's matter.js Matter Server:

- Before: post-reboot resubscribe carries `event_min: Some(N)`; device
  emits from `#1`; controller filters everything; HA never sees button
  events.
- After: device-side log shows `Loaded events counter from storage` at
  boot; resubscribe Reports advance from the persisted epoch boundary;
  all events `>= event_min` so they reach HA.