### PR TITLE
Emit BasicInformation::StartUp event after data model startup

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ use embassy_time::Duration;
 
 use rs_matter::crypto::Crypto;
 use rs_matter::dm::clusters::basic_info::BasicInfoConfig;
+use rs_matter::dm::clusters::decl::basic_information::StartUp;
 use rs_matter::dm::clusters::dev_att::DeviceAttestation;
 use rs_matter::dm::clusters::gen_diag::NetifDiag;
 use rs_matter::dm::clusters::net_comm::NetworksAccess;
@@ -670,6 +671,8 @@ where
         // Reset the Matter transport buffers and all sessions first
         // self.matter().reset_transport()?;
 
+        self.emit_startup_event(dm);
+
         let mut responder = pin!(self.run_responder(dm));
         let mut dm_job = pin!(dm.run());
 
@@ -690,10 +693,31 @@ where
         // Reset the Matter transport buffers and all sessions first
         // self.matter().reset_transport()?;
 
+        self.emit_startup_event(dm);
+
         let mut responder = pin_alloc!(self.bump, self.run_responder_with_bump(dm));
         let mut dm_job = pin!(dm.run());
 
         select(&mut responder, &mut dm_job).coalesce().await
+    }
+
+    /// Emit `BasicInformation::StartUp` on the root endpoint, as required
+    /// by Matter 1.5.1 Core §11.1.6.1 (SHALL).
+    fn emit_startup_event<C, H, S, W>(&self, dm: &MatterStackDataModel<'_, C, H, S, W>)
+    where
+        C: Crypto,
+        H: DataModelHandler,
+        S: KvBlobStoreAccess,
+        W: NetworksAccess,
+    {
+        let sw_ver = self.matter().dev_det().sw_ver;
+        match StartUp::emit_for(dm, 0, |b| b.software_version(sw_ver)?.end()) {
+            Ok(event_number) => info!(
+                "BasicInformation::StartUp emitted (sw_ver={}, event_number={})",
+                sw_ver, event_number,
+            ),
+            Err(e) => warn!("Failed to emit BasicInformation::StartUp: {:?}", e),
+        }
     }
 
     async fn run_responder<C, H, S, W>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,7 +252,6 @@ where
     store_buf: MatterKvBlobStoreBuf,
     bump: Bump<B>,
     run_lock: IfMutex<()>,
-    startup_event_emitted: IfMutex<bool>,
     #[allow(unused)]
     network: N,
     //netif_conf: Signal<Option<NetifConf>>,
@@ -278,7 +277,6 @@ where
             store_buf: MatterKvBlobStoreBuf::new(),
             bump: Bump::new(),
             run_lock: IfMutex::new(()),
-            startup_event_emitted: IfMutex::new(false),
             network: N::INIT,
             //netif_conf: Signal::new(None),
         }
@@ -303,7 +301,6 @@ where
             store_buf <- MatterKvBlobStoreBuf::init(),
             bump <- Bump::init(),
             run_lock <- IfMutex::init(()),
-            startup_event_emitted <- IfMutex::init(false),
             network <- N::init(),
             //netif_conf: Signal::new(None),
         })
@@ -674,7 +671,7 @@ where
         // Reset the Matter transport buffers and all sessions first
         // self.matter().reset_transport()?;
 
-        self.emit_startup_event_once(dm).await;
+        self.emit_startup_event(dm);
 
         let mut responder = pin!(self.run_responder(dm));
         let mut dm_job = pin!(dm.run());
@@ -696,7 +693,7 @@ where
         // Reset the Matter transport buffers and all sessions first
         // self.matter().reset_transport()?;
 
-        self.emit_startup_event_once(dm).await;
+        self.emit_startup_event(dm);
 
         let mut responder = pin_alloc!(self.bump, self.run_responder_with_bump(dm));
         let mut dm_job = pin!(dm.run());
@@ -706,29 +703,19 @@ where
 
     /// Emit `BasicInformation::StartUp` on the root endpoint, as required
     /// by Matter 1.5.1 Core §11.1.6.1 (SHALL).
-    async fn emit_startup_event_once<C, H, S, W>(&self, dm: &MatterStackDataModel<'_, C, H, S, W>)
+    fn emit_startup_event<C, H, S, W>(&self, dm: &MatterStackDataModel<'_, C, H, S, W>)
     where
         C: Crypto,
         H: DataModelHandler,
         S: KvBlobStoreAccess,
         W: NetworksAccess,
     {
-        let mut emitted = self.startup_event_emitted.lock().await;
-
-        if *emitted {
-            return;
-        }
-
         let sw_ver = self.matter().dev_det().sw_ver;
         match StartUp::emit_for(dm, 0, |b| b.software_version(sw_ver)?.end()) {
-            Ok(event_number) => {
-                *emitted = true;
-
-                info!(
-                    "BasicInformation::StartUp emitted (sw_ver={}, event_number={})",
-                    sw_ver, event_number,
-                );
-            }
+            Ok(event_number) => info!(
+                "BasicInformation::StartUp emitted (sw_ver={}, event_number={})",
+                sw_ver, event_number,
+            ),
             Err(e) => warn!("Failed to emit BasicInformation::StartUp: {:?}", e),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,6 +252,7 @@ where
     store_buf: MatterKvBlobStoreBuf,
     bump: Bump<B>,
     run_lock: IfMutex<()>,
+    startup_event_emitted: IfMutex<bool>,
     #[allow(unused)]
     network: N,
     //netif_conf: Signal<Option<NetifConf>>,
@@ -277,6 +278,7 @@ where
             store_buf: MatterKvBlobStoreBuf::new(),
             bump: Bump::new(),
             run_lock: IfMutex::new(()),
+            startup_event_emitted: IfMutex::new(false),
             network: N::INIT,
             //netif_conf: Signal::new(None),
         }
@@ -301,6 +303,7 @@ where
             store_buf <- MatterKvBlobStoreBuf::init(),
             bump <- Bump::init(),
             run_lock <- IfMutex::init(()),
+            startup_event_emitted <- IfMutex::init(false),
             network <- N::init(),
             //netif_conf: Signal::new(None),
         })
@@ -671,7 +674,7 @@ where
         // Reset the Matter transport buffers and all sessions first
         // self.matter().reset_transport()?;
 
-        self.emit_startup_event(dm);
+        self.emit_startup_event_once(dm).await;
 
         let mut responder = pin!(self.run_responder(dm));
         let mut dm_job = pin!(dm.run());
@@ -693,7 +696,7 @@ where
         // Reset the Matter transport buffers and all sessions first
         // self.matter().reset_transport()?;
 
-        self.emit_startup_event(dm);
+        self.emit_startup_event_once(dm).await;
 
         let mut responder = pin_alloc!(self.bump, self.run_responder_with_bump(dm));
         let mut dm_job = pin!(dm.run());
@@ -703,19 +706,29 @@ where
 
     /// Emit `BasicInformation::StartUp` on the root endpoint, as required
     /// by Matter 1.5.1 Core §11.1.6.1 (SHALL).
-    fn emit_startup_event<C, H, S, W>(&self, dm: &MatterStackDataModel<'_, C, H, S, W>)
+    async fn emit_startup_event_once<C, H, S, W>(&self, dm: &MatterStackDataModel<'_, C, H, S, W>)
     where
         C: Crypto,
         H: DataModelHandler,
         S: KvBlobStoreAccess,
         W: NetworksAccess,
     {
+        let mut emitted = self.startup_event_emitted.lock().await;
+
+        if *emitted {
+            return;
+        }
+
         let sw_ver = self.matter().dev_det().sw_ver;
         match StartUp::emit_for(dm, 0, |b| b.software_version(sw_ver)?.end()) {
-            Ok(event_number) => info!(
-                "BasicInformation::StartUp emitted (sw_ver={}, event_number={})",
-                sw_ver, event_number,
-            ),
+            Ok(event_number) => {
+                *emitted = true;
+
+                info!(
+                    "BasicInformation::StartUp emitted (sw_ver={}, event_number={})",
+                    sw_ver, event_number,
+                );
+            }
             Err(e) => warn!("Failed to emit BasicInformation::StartUp: {:?}", e),
         }
     }


### PR DESCRIPTION
## Summary

Emit `BasicInformation::StartUp` on the root endpoint from `run_dm` /
`run_dm_with_bump`, as required by Matter 1.5.1 Core §11.1.6.1 (SHALL).
Every Node has to emit it "as soon as reasonable after completing a
boot or reboot process," with `SoftwareVersion` matching the
BasicInformation attribute of the same name.

Today, applications built on `rs-matter-stack` get no help with this —
each one has to wire its own `Handler` impl into the chain just to emit
one mandatory event. Stack-level emission means every downstream
project is spec-compliant without per-app boilerplate.

## Implementation

A small `emit_startup_event_once(dm)` helper is called at the top of
`run_dm` and `run_dm_with_bump`, before the responder and DM `run()`
future start. By that point the `DataModel` (and its event ringbuf +
`EventNumber` persistence from #39) is fully initialised, and every
Ethernet / wireless run-loop in the crate funnels through one of those
two paths.

`run_dm` is called more than once per boot in the wireless flow — once
from the commissioning task (`wireless/thread.rs:507`,
`wireless/wifi.rs:504`) and once from the operational task
(`wireless/thread.rs:579`, `wireless/wifi.rs:576`). §11.1.6.1's "boot
or reboot process" wording is per process boot, not per network attach,
so the helper is gated by a `startup_event_emitted: IfMutex<bool>`
field on `MatterStack` that flips to `true` on the first successful
emission and short-circuits subsequent calls. On `Err` the flag stays
`false` so a transient KV failure on the `EventNumber` epoch-boundary
write gets retried on the next `run_dm`.

`SoftwareVersion` is pulled from `self.matter().dev_det().sw_ver`.
Failures are logged at `warn!`, not propagated — a zero-sized events
ringbuf already silently drops events on emission, and there's no
reason to fail the run loop over a missing observability event.

If the device boots uncommissioned, StartUp fires during the
commissioning `run_dm`, before any controller is bound. It lands in
the ringbuf and the commissioner picks it up on its first subscribe
after CASE — which is correct per the buffered event-subscription
model and consistent with §11.1.6.1's silence on *who* must receive
the event.

## Test plan

- [x] `cargo build` / `cargo clippy --no-deps` clean on `next` HEAD.
- [x] End-to-end on ESP32-C6 + Home Assistant matter-server (matter.js):
  device-side log shows `BasicInformation::StartUp emitted (sw_ver=1,
  event_number=50000)` ~2.3 s after boot; controller-side log shows
  `ClientEventEmitter Received event basicInformation.startUp on
  server-2-134b.@1:37 softwareVersion: 1` after the next subscribe.
  `EventNumber` increments by `EVENT_NUMBER_EPOCH_SIZE` (10000) per
  reboot, confirming #39's persistence still works through this path.