### PR TITLE
Reduce bloat

### DIFF
--- a/src/wireless.rs
+++ b/src/wireless.rs
@@ -1,12 +1,16 @@
 use core::borrow::BorrowMut;
+use core::marker::PhantomData;
 use core::pin::pin;
 
 use embassy_futures::select::{select, select3};
 
 use rs_matter::crypto::Crypto;
 use rs_matter::dm::clusters::gen_diag::NetifDiag;
-use rs_matter::dm::clusters::net_comm::{NetCtl, SharedNetworks};
+use rs_matter::dm::clusters::net_comm::{
+    self, NetCtl, NetCtlError, NetworkType, SharedNetworks, WirelessCreds,
+};
 use rs_matter::dm::clusters::wifi_diag::WirelessDiag;
+use rs_matter::dm::clusters::{thread_diag, wifi_diag};
 use rs_matter::dm::networks::wireless::{
     NetCtlState, WirelessMgr, WirelessNetwork, WirelessNetworks, MAX_CREDS_SIZE,
 };
@@ -19,6 +23,7 @@ use rs_matter::transport::network::NoNetwork;
 use rs_matter::utils::cell::RefCell;
 use rs_matter::utils::init::{init, zeroed, Init};
 use rs_matter::utils::select::Coalesce;
+use rs_matter::utils::sync::DynBase;
 use rs_matter::utils::sync::{blocking, IfMutex};
 
 use crate::ble::GattPeripheral;
@@ -94,6 +99,324 @@ where
     /// Return a reference to the networks storage.
     pub fn networks(&self) -> &SharedNetworks<WirelessNetworks<MAX_WIRELESS_NETWORKS, T>> {
         &self.networks
+    }
+}
+
+/// A composite wireless network controller that is the SAME concrete type during
+/// both the (BLE) commissioning phase and the operational (Thread/Wifi) phase.
+///
+/// This exists purely to avoid building two structurally-different Matter handler
+/// chains per device. `DataModel::handle` and every generated cluster handler
+/// adaptor are monomorphized over the whole handler-chain tuple type; if the
+/// net-ctl slot has a different type per phase, the entire dispatch tree is
+/// compiled twice (~tens of KiB of duplicated `.text` on embedded targets).
+///
+/// By using `WirelessNetCtl<Q>` in *both* phases — `Commissioning` before the
+/// operational controller exists, `Operational(&Q)` afterwards — the chain type
+/// is identical across phases and the dispatch tree monomorphizes once.
+///
+/// The `Commissioning` variant reproduces the behavior of the former
+/// `NoopWirelessNetCtl`: `scan` errors with `InvalidAction`, `connect` only
+/// checks the creds match the network type, and every diag returns its default.
+/// The `Operational` variant delegates to the real controller `Q`.
+///
+/// `Q` is named identically at every phase via the wireless driver's associated
+/// net-ctl type (see the `Thread`/`Gatt` driver traits), so even the
+/// commissioning phase — which has no controller value — can still name the type.
+pub enum WirelessNetCtl<'a, Q> {
+    /// Commissioning phase: no operational controller yet (BLE only).
+    Commissioning(NetworkType),
+    /// Operational phase: delegate to the real controller.
+    Operational(&'a Q),
+}
+
+impl<Q> net_comm::NetCtl for WirelessNetCtl<'_, Q>
+where
+    Q: net_comm::NetCtl,
+{
+    fn net_type(&self) -> NetworkType {
+        match self {
+            Self::Commissioning(net_type) => *net_type,
+            Self::Operational(q) => q.net_type(),
+        }
+    }
+
+    fn connect_max_time_seconds(&self) -> u8 {
+        match self {
+            Self::Commissioning(_) => 0,
+            Self::Operational(q) => q.connect_max_time_seconds(),
+        }
+    }
+
+    fn scan_max_time_seconds(&self) -> u8 {
+        match self {
+            Self::Commissioning(_) => 0,
+            Self::Operational(q) => q.scan_max_time_seconds(),
+        }
+    }
+
+    fn supported_wifi_bands<F>(&self, f: F) -> Result<(), Error>
+    where
+        F: FnMut(net_comm::WiFiBandEnum) -> Result<(), Error>,
+    {
+        match self {
+            Self::Commissioning(_) => Ok(()),
+            Self::Operational(q) => q.supported_wifi_bands(f),
+        }
+    }
+
+    fn supported_thread_features(&self) -> net_comm::ThreadCapabilitiesBitmap {
+        match self {
+            Self::Commissioning(_) => net_comm::ThreadCapabilitiesBitmap::empty(),
+            Self::Operational(q) => q.supported_thread_features(),
+        }
+    }
+
+    fn thread_version(&self) -> u16 {
+        match self {
+            Self::Commissioning(_) => 0,
+            Self::Operational(q) => q.thread_version(),
+        }
+    }
+
+    async fn scan<F>(&self, network: Option<&[u8]>, f: F) -> Result<(), NetCtlError>
+    where
+        F: FnMut(&net_comm::NetworkScanInfo) -> Result<(), Error>,
+    {
+        match self {
+            // Matches the former `NoopWirelessNetCtl::scan`.
+            Self::Commissioning(_) => Err(NetCtlError::Other(
+                rs_matter::error::ErrorCode::InvalidAction.into(),
+            )),
+            Self::Operational(q) => q.scan(network, f).await,
+        }
+    }
+
+    async fn connect(&self, creds: &WirelessCreds<'_>) -> Result<(), NetCtlError> {
+        match self {
+            // Matches the former `NoopWirelessNetCtl::connect`.
+            Self::Commissioning(net_type) => Ok(creds.check_match(*net_type)?),
+            Self::Operational(q) => q.connect(creds).await,
+        }
+    }
+}
+
+impl<Q> NetChangeNotif for WirelessNetCtl<'_, Q>
+where
+    Q: NetChangeNotif,
+{
+    async fn wait_changed(&self) {
+        match self {
+            Self::Commissioning(_) => core::future::pending().await,
+            Self::Operational(q) => q.wait_changed().await,
+        }
+    }
+}
+
+#[cfg(feature = "sync-mutex")]
+impl<Q> DynBase for WirelessNetCtl<'_, Q> where Q: Send + Sync {}
+
+#[cfg(not(feature = "sync-mutex"))]
+impl<Q> DynBase for WirelessNetCtl<'_, Q> {}
+
+impl<Q> WirelessDiag for WirelessNetCtl<'_, Q>
+where
+    Q: WirelessDiag,
+{
+    fn connected(&self) -> Result<bool, Error> {
+        match self {
+            Self::Commissioning(_) => Ok(false),
+            Self::Operational(q) => q.connected(),
+        }
+    }
+}
+
+// For `WifiDiag`/`ThreadDiag`, the `Commissioning` variant reproduces each
+// method's trait default (matching the former `NoopWirelessNetCtl`, which impl'd
+// both traits empty), and the `Operational` variant delegates to the real
+// controller. The defaults are: `Ok(None)` for the scalar accessors, `Ok(())` /
+// `f(None)` for the closure-based accessors, and `Nullable::none()` for the
+// `WifiDiag` nullable accessors — kept in sync with rs-matter's trait defaults.
+impl<Q> wifi_diag::WifiDiag for WirelessNetCtl<'_, Q>
+where
+    Q: wifi_diag::WifiDiag,
+{
+    fn bssid(&self, f: &mut dyn FnMut(Option<&[u8]>) -> Result<(), Error>) -> Result<(), Error> {
+        match self {
+            Self::Commissioning(_) => f(None),
+            Self::Operational(q) => q.bssid(f),
+        }
+    }
+
+    fn security_type(
+        &self,
+    ) -> Result<rs_matter::tlv::Nullable<wifi_diag::SecurityTypeEnum>, Error> {
+        match self {
+            Self::Commissioning(_) => Ok(rs_matter::tlv::Nullable::none()),
+            Self::Operational(q) => q.security_type(),
+        }
+    }
+
+    fn wi_fi_version(&self) -> Result<rs_matter::tlv::Nullable<wifi_diag::WiFiVersionEnum>, Error> {
+        match self {
+            Self::Commissioning(_) => Ok(rs_matter::tlv::Nullable::none()),
+            Self::Operational(q) => q.wi_fi_version(),
+        }
+    }
+
+    fn channel_number(&self) -> Result<rs_matter::tlv::Nullable<u16>, Error> {
+        match self {
+            Self::Commissioning(_) => Ok(rs_matter::tlv::Nullable::none()),
+            Self::Operational(q) => q.channel_number(),
+        }
+    }
+
+    fn rssi(&self) -> Result<rs_matter::tlv::Nullable<i8>, Error> {
+        match self {
+            Self::Commissioning(_) => Ok(rs_matter::tlv::Nullable::none()),
+            Self::Operational(q) => q.rssi(),
+        }
+    }
+}
+
+impl<Q> thread_diag::ThreadDiag for WirelessNetCtl<'_, Q>
+where
+    Q: thread_diag::ThreadDiag,
+{
+    fn channel(&self) -> Result<Option<u16>, Error> {
+        match self {
+            Self::Commissioning(_) => Ok(None),
+            Self::Operational(q) => q.channel(),
+        }
+    }
+    fn routing_role(&self) -> Result<Option<thread_diag::RoutingRoleEnum>, Error> {
+        match self {
+            Self::Commissioning(_) => Ok(None),
+            Self::Operational(q) => q.routing_role(),
+        }
+    }
+    fn network_name(
+        &self,
+        f: &mut dyn FnMut(Option<&str>) -> Result<(), Error>,
+    ) -> Result<(), Error> {
+        match self {
+            Self::Commissioning(_) => f(None),
+            Self::Operational(q) => q.network_name(f),
+        }
+    }
+    fn pan_id(&self) -> Result<Option<u16>, Error> {
+        match self {
+            Self::Commissioning(_) => Ok(None),
+            Self::Operational(q) => q.pan_id(),
+        }
+    }
+    fn extended_pan_id(&self) -> Result<Option<u64>, Error> {
+        match self {
+            Self::Commissioning(_) => Ok(None),
+            Self::Operational(q) => q.extended_pan_id(),
+        }
+    }
+    fn mesh_local_prefix(
+        &self,
+        f: &mut dyn FnMut(Option<&[u8]>) -> Result<(), Error>,
+    ) -> Result<(), Error> {
+        match self {
+            Self::Commissioning(_) => f(None),
+            Self::Operational(q) => q.mesh_local_prefix(f),
+        }
+    }
+    fn neighbor_table(
+        &self,
+        f: &mut dyn FnMut(&thread_diag::NeighborTable) -> Result<(), Error>,
+    ) -> Result<(), Error> {
+        match self {
+            Self::Commissioning(_) => Ok(()),
+            Self::Operational(q) => q.neighbor_table(f),
+        }
+    }
+    fn route_table(
+        &self,
+        f: &mut dyn FnMut(&thread_diag::RouteTable) -> Result<(), Error>,
+    ) -> Result<(), Error> {
+        match self {
+            Self::Commissioning(_) => Ok(()),
+            Self::Operational(q) => q.route_table(f),
+        }
+    }
+    fn partition_id(&self) -> Result<Option<u32>, Error> {
+        match self {
+            Self::Commissioning(_) => Ok(None),
+            Self::Operational(q) => q.partition_id(),
+        }
+    }
+    fn weighting(&self) -> Result<Option<u16>, Error> {
+        match self {
+            Self::Commissioning(_) => Ok(None),
+            Self::Operational(q) => q.weighting(),
+        }
+    }
+    fn data_version(&self) -> Result<Option<u16>, Error> {
+        match self {
+            Self::Commissioning(_) => Ok(None),
+            Self::Operational(q) => q.data_version(),
+        }
+    }
+    fn stable_data_version(&self) -> Result<Option<u16>, Error> {
+        match self {
+            Self::Commissioning(_) => Ok(None),
+            Self::Operational(q) => q.stable_data_version(),
+        }
+    }
+    fn leader_router_id(&self) -> Result<Option<u8>, Error> {
+        match self {
+            Self::Commissioning(_) => Ok(None),
+            Self::Operational(q) => q.leader_router_id(),
+        }
+    }
+    fn ext_address(&self) -> Result<Option<u64>, Error> {
+        match self {
+            Self::Commissioning(_) => Ok(None),
+            Self::Operational(q) => q.ext_address(),
+        }
+    }
+    fn rloc_16(&self) -> Result<Option<u16>, Error> {
+        match self {
+            Self::Commissioning(_) => Ok(None),
+            Self::Operational(q) => q.rloc_16(),
+        }
+    }
+    fn security_policy(&self) -> Result<Option<thread_diag::SecurityPolicy>, Error> {
+        match self {
+            Self::Commissioning(_) => Ok(None),
+            Self::Operational(q) => q.security_policy(),
+        }
+    }
+    fn channel_page0_mask(
+        &self,
+        f: &mut dyn FnMut(Option<&[u8]>) -> Result<(), Error>,
+    ) -> Result<(), Error> {
+        match self {
+            Self::Commissioning(_) => f(None),
+            Self::Operational(q) => q.channel_page0_mask(f),
+        }
+    }
+    fn operational_dataset_components(
+        &self,
+        f: &mut dyn FnMut(Option<&thread_diag::OperationalDatasetComponents>) -> Result<(), Error>,
+    ) -> Result<(), Error> {
+        match self {
+            Self::Commissioning(_) => f(None),
+            Self::Operational(q) => q.operational_dataset_components(f),
+        }
+    }
+    fn active_network_faults_list(
+        &self,
+        f: &mut dyn FnMut(thread_diag::NetworkFaultEnum) -> Result<(), Error>,
+    ) -> Result<(), Error> {
+        match self {
+            Self::Commissioning(_) => Ok(()),
+            Self::Operational(q) => q.active_network_faults_list(f),
+        }
     }
 }
 
@@ -355,7 +678,7 @@ impl<S, N, C, M, G> PreexistingWireless<S, N, C, M, G> {
     }
 }
 
-pub(crate) struct MatterStackWirelessTask<'a, const B: usize, T, E, C, H, S, U>
+pub(crate) struct MatterStackWirelessTask<'a, const B: usize, T, E, C, H, S, U, Q>
 where
     T: WirelessNetwork,
     E: Embedding,
@@ -365,4 +688,9 @@ where
     handler: H,
     kv: S,
     user_task: U,
+    // The operational net-ctl type. Phantom-only: it makes the commissioning and
+    // operational phases name the SAME `WirelessNetCtl<Q>` chain type so the data
+    // model dispatch monomorphizes once. `fn() -> Q` keeps the task's auto-traits
+    // and variance independent of `Q`.
+    _net_ctl: PhantomData<fn() -> Q>,
 }

--- a/src/wireless/thread.rs
+++ b/src/wireless/thread.rs
@@ -1,4 +1,5 @@
 use core::future::Future;
+use core::marker::PhantomData;
 use core::pin::pin;
 
 use embassy_futures::select::{select, select3, select4};
@@ -26,7 +27,7 @@ use rs_matter::utils::select::Coalesce;
 use crate::mdns::Mdns;
 use crate::nal::NetStack;
 use crate::network::Embedding;
-use crate::wireless::{GattPeripheral, GattTask, MatterStackWirelessTask};
+use crate::wireless::{GattPeripheral, GattTask, MatterStackWirelessTask, WirelessNetCtl};
 use crate::{pin_alloc, UserTask};
 
 use super::{Gatt, PreexistingWireless, WirelessMatterStack};
@@ -185,12 +186,25 @@ where
         S: KvBlobStoreAccess + 't,
         U: UserTask + 't,
     {
-        thread.run(MatterStackWirelessTask {
+        // The coex task never builds a `WirelessNetCtl` chain via `Q`, so its
+        // phantom net-ctl type is an irrelevant placeholder.
+        thread.run(MatterStackWirelessTask::<
+            '_,
+            B,
+            wireless::Thread,
+            E,
+            C,
+            H,
+            S,
+            U,
+            NoopWirelessNetCtl,
+        > {
             stack: self,
             crypto,
             handler,
             kv,
             user_task: user,
+            _net_ctl: PhantomData,
         })
     }
 
@@ -215,12 +229,23 @@ where
             if !commissioned {
                 Gatt::run(
                     &mut thread,
-                    MatterStackWirelessTask {
+                    MatterStackWirelessTask::<
+                        '_,
+                        B,
+                        wireless::Thread,
+                        E,
+                        &C,
+                        &H,
+                        &S,
+                        &mut U,
+                        <W as Thread>::NetCtl<'_>,
+                    > {
                         stack: self,
                         crypto: &crypto,
                         handler: &handler,
                         kv: &kv,
                         user_task: &mut user,
+                        _net_ctl: PhantomData,
                     },
                 )
                 .await?;
@@ -229,7 +254,7 @@ where
             if commissioned {
                 let net_ctl = NetCtlWithStatusImpl::new(
                     &self.network.net_state,
-                    NoopWirelessNetCtl::new(NetworkType::Thread),
+                    WirelessNetCtl::<<W as Thread>::NetCtl<'_>>::Commissioning(NetworkType::Thread),
                 );
 
                 let sys =
@@ -246,12 +271,23 @@ where
 
             Thread::run(
                 &mut thread,
-                MatterStackWirelessTask {
+                MatterStackWirelessTask::<
+                    '_,
+                    B,
+                    wireless::Thread,
+                    E,
+                    &C,
+                    &H,
+                    &S,
+                    &mut U,
+                    <W as Thread>::NetCtl<'_>,
+                > {
                     stack: self,
                     crypto: &crypto,
                     handler: &handler,
                     kv: &kv,
                     user_task: &mut user,
+                    _net_ctl: PhantomData,
                 },
             )
             .await?;
@@ -336,6 +372,15 @@ where
 
 /// A trait for running a task within a context where the wireless interface is initialized and operable
 pub trait Thread {
+    /// The Thread network controller type this driver produces in its operational
+    /// phase. Naming it here lets the commissioning and operational handler chains
+    /// be built with the SAME `WirelessNetCtl<Self::NetCtl<'_>>` net-ctl type,
+    /// yielding a single handler-chain monomorphization. The bound is Thread's own
+    /// (`ThreadDiag`) — a Thread controller is never asked to be a Wifi one.
+    type NetCtl<'a>: NetCtl + ThreadDiag + NetChangeNotif
+    where
+        Self: 'a;
+
     /// Setup the radio to operate in wireless (Wifi or Thread) mode
     /// and run the given task
     async fn run<T>(&mut self, task: T) -> Result<(), Error>
@@ -347,6 +392,11 @@ impl<T> Thread for &mut T
 where
     T: Thread,
 {
+    type NetCtl<'a>
+        = T::NetCtl<'a>
+    where
+        Self: 'a;
+
     fn run<A>(&mut self, task: A) -> impl Future<Output = Result<(), Error>>
     where
         A: ThreadTask,
@@ -432,6 +482,13 @@ where
     C: NetCtl + ThreadDiag + NetChangeNotif,
     M: Mdns,
 {
+    // The task receives `&self.net_ctl` (a `&C`), so the chain net-ctl type is
+    // `&'a C` (which satisfies the bounds via the blanket `impl Trait for &T`).
+    type NetCtl<'a>
+        = &'a C
+    where
+        Self: 'a;
+
     async fn run<T>(&mut self, mut task: T) -> Result<(), Error>
     where
         T: ThreadTask,
@@ -464,13 +521,14 @@ where
     }
 }
 
-impl<'a, const B: usize, E, C, H, S, X> GattTask
-    for MatterStackWirelessTask<'a, B, wireless::Thread, E, C, H, S, X>
+impl<'a, const B: usize, E, C, H, S, X, Q> GattTask
+    for MatterStackWirelessTask<'a, B, wireless::Thread, E, C, H, S, X, Q>
 where
     E: Embedding,
     C: Crypto,
     H: DataModelHandler,
     S: KvBlobStoreAccess,
+    Q: NetCtl + ThreadDiag + NetChangeNotif,
 {
     async fn run<P>(&mut self, peripheral: P) -> Result<(), Error>
     where
@@ -478,7 +536,7 @@ where
     {
         let net_ctl = NetCtlWithStatusImpl::new(
             &self.stack.network.net_state,
-            NoopWirelessNetCtl::new(NetworkType::Thread),
+            WirelessNetCtl::<Q>::Commissioning(NetworkType::Thread),
         );
 
         let sys = self.stack.root_handler(
@@ -510,14 +568,15 @@ where
     }
 }
 
-impl<'a, const B: usize, E, C, H, S, X> ThreadTask
-    for MatterStackWirelessTask<'a, B, wireless::Thread, E, C, H, S, X>
+impl<'a, const B: usize, E, C, H, S, X, Z> ThreadTask
+    for MatterStackWirelessTask<'a, B, wireless::Thread, E, C, H, S, X, Z>
 where
     E: Embedding,
     C: Crypto,
     H: DataModelHandler,
     S: KvBlobStoreAccess,
     X: UserTask,
+    Z: NetCtl + ThreadDiag + NetChangeNotif,
 {
     async fn run<T, N, Q, D>(
         &mut self,
@@ -538,7 +597,10 @@ where
 
         let mut mgr = WirelessMgr::new(&self.stack.network.networks, &net_ctl, &mut buf);
 
-        let net_ctl_s = NetCtlWithStatusImpl::new(&self.stack.network.net_state, &net_ctl);
+        let net_ctl_s = NetCtlWithStatusImpl::new(
+            &self.stack.network.net_state,
+            WirelessNetCtl::Operational(&net_ctl),
+        );
 
         let sys = self.stack.root_handler(
             &false,
@@ -591,14 +653,15 @@ where
     }
 }
 
-impl<'a, const B: usize, E, C, H, S, X> ThreadCoexTask
-    for MatterStackWirelessTask<'a, B, wireless::Thread, E, C, H, S, X>
+impl<'a, const B: usize, E, C, H, S, X, Z> ThreadCoexTask
+    for MatterStackWirelessTask<'a, B, wireless::Thread, E, C, H, S, X, Z>
 where
     E: Embedding,
     C: Crypto,
     H: DataModelHandler,
     S: KvBlobStoreAccess,
     X: UserTask,
+    Z: NetCtl + ThreadDiag + NetChangeNotif,
 {
     async fn run<T, N, Q, D, G>(
         &mut self,
@@ -617,7 +680,10 @@ where
     {
         info!("Thread and BLE drivers started");
 
-        let net_ctl_s = NetCtlWithStatusImpl::new(&self.stack.network.net_state, &net_ctl);
+        let net_ctl_s = NetCtlWithStatusImpl::new(
+            &self.stack.network.net_state,
+            WirelessNetCtl::Operational(&net_ctl),
+        );
 
         let sys = self.stack.root_handler(
             &true,

--- a/src/wireless/wifi.rs
+++ b/src/wireless/wifi.rs
@@ -1,4 +1,5 @@
 use core::future::Future;
+use core::marker::PhantomData;
 use core::pin::pin;
 
 use embassy_futures::select::{select, select3, select4};
@@ -26,7 +27,7 @@ use rs_matter::utils::select::Coalesce;
 use crate::mdns::Mdns;
 use crate::nal::NetStack;
 use crate::network::Embedding;
-use crate::wireless::{GattPeripheral, MatterStackWirelessTask};
+use crate::wireless::{GattPeripheral, MatterStackWirelessTask, WirelessNetCtl};
 use crate::{pin_alloc, UserTask};
 
 use super::{Gatt, GattTask, PreexistingWireless, WirelessMatterStack};
@@ -182,12 +183,25 @@ where
         S: KvBlobStoreAccess + 't,
         U: UserTask + 't,
     {
-        wifi.run(MatterStackWirelessTask {
+        // The coex task never builds a `WirelessNetCtl` chain via `Q`, so its
+        // phantom net-ctl type is an irrelevant placeholder.
+        wifi.run(MatterStackWirelessTask::<
+            '_,
+            B,
+            wireless::Wifi,
+            E,
+            C,
+            H,
+            S,
+            U,
+            NoopWirelessNetCtl,
+        > {
             stack: self,
             crypto,
             handler,
             kv,
             user_task: user,
+            _net_ctl: PhantomData,
         })
     }
 
@@ -212,12 +226,23 @@ where
             if !commissioned {
                 Gatt::run(
                     &mut wifi,
-                    MatterStackWirelessTask {
+                    MatterStackWirelessTask::<
+                        '_,
+                        B,
+                        wireless::Wifi,
+                        E,
+                        &C,
+                        &H,
+                        &S,
+                        &mut U,
+                        <W as Wifi>::NetCtl<'_>,
+                    > {
                         stack: self,
                         crypto: &crypto,
                         handler: &handler,
                         kv: &kv,
                         user_task: &mut user,
+                        _net_ctl: PhantomData,
                     },
                 )
                 .await?;
@@ -226,7 +251,7 @@ where
             if commissioned {
                 let net_ctl = NetCtlWithStatusImpl::new(
                     &self.network.net_state,
-                    NoopWirelessNetCtl::new(NetworkType::Wifi),
+                    WirelessNetCtl::<<W as Wifi>::NetCtl<'_>>::Commissioning(NetworkType::Wifi),
                 );
 
                 let sys =
@@ -243,12 +268,23 @@ where
 
             Wifi::run(
                 &mut wifi,
-                MatterStackWirelessTask {
+                MatterStackWirelessTask::<
+                    '_,
+                    B,
+                    wireless::Wifi,
+                    E,
+                    &C,
+                    &H,
+                    &S,
+                    &mut U,
+                    <W as Wifi>::NetCtl<'_>,
+                > {
                     stack: self,
                     crypto: &crypto,
                     handler: &handler,
                     kv: &kv,
                     user_task: &mut user,
+                    _net_ctl: PhantomData,
                 },
             )
             .await?;
@@ -333,6 +369,15 @@ where
 
 /// A trait for running a task within a context where the wireless interface is initialized and operable
 pub trait Wifi {
+    /// The Wifi network controller type this driver produces in its operational
+    /// phase. Naming it here lets the commissioning and operational handler chains
+    /// be built with the SAME `WirelessNetCtl<Self::NetCtl<'_>>` net-ctl type,
+    /// yielding a single handler-chain monomorphization. The bound is Wifi's own
+    /// (`WifiDiag`) — a Wifi controller is never asked to be a Thread one.
+    type NetCtl<'a>: NetCtl + WifiDiag + NetChangeNotif
+    where
+        Self: 'a;
+
     /// Setup the radio to operate in wireless (Wifi or Thread) mode
     /// and run the given task
     async fn run<T>(&mut self, task: T) -> Result<(), Error>
@@ -344,6 +389,11 @@ impl<T> Wifi for &mut T
 where
     T: Wifi,
 {
+    type NetCtl<'a>
+        = T::NetCtl<'a>
+    where
+        Self: 'a;
+
     fn run<A>(&mut self, task: A) -> impl Future<Output = Result<(), Error>>
     where
         A: WifiTask,
@@ -429,6 +479,13 @@ where
     C: NetCtl + WifiDiag + NetChangeNotif,
     M: Mdns,
 {
+    // The task receives `&self.net_ctl` (a `&C`), so the chain net-ctl type is
+    // `&'a C` (which satisfies the bounds via the blanket `impl Trait for &T`).
+    type NetCtl<'a>
+        = &'a C
+    where
+        Self: 'a;
+
     async fn run<T>(&mut self, mut task: T) -> Result<(), Error>
     where
         T: WifiTask,
@@ -461,13 +518,14 @@ where
     }
 }
 
-impl<'a, const B: usize, E, C, H, S, U> GattTask
-    for MatterStackWirelessTask<'a, B, wireless::Wifi, E, C, H, S, U>
+impl<'a, const B: usize, E, C, H, S, U, Q> GattTask
+    for MatterStackWirelessTask<'a, B, wireless::Wifi, E, C, H, S, U, Q>
 where
     E: Embedding,
     C: Crypto,
     H: DataModelHandler,
     S: KvBlobStoreAccess,
+    Q: NetCtl + WifiDiag + NetChangeNotif,
 {
     async fn run<P>(&mut self, peripheral: P) -> Result<(), Error>
     where
@@ -475,7 +533,7 @@ where
     {
         let net_ctl = NetCtlWithStatusImpl::new(
             &self.stack.network.net_state,
-            NoopWirelessNetCtl::new(NetworkType::Wifi),
+            WirelessNetCtl::<Q>::Commissioning(NetworkType::Wifi),
         );
 
         let sys = self.stack.root_handler(
@@ -507,14 +565,15 @@ where
     }
 }
 
-impl<'a, const B: usize, E, C, H, S, X> WifiTask
-    for MatterStackWirelessTask<'a, B, wireless::Wifi, E, C, H, S, X>
+impl<'a, const B: usize, E, C, H, S, X, Z> WifiTask
+    for MatterStackWirelessTask<'a, B, wireless::Wifi, E, C, H, S, X, Z>
 where
     E: Embedding,
     C: Crypto,
     H: DataModelHandler,
     S: KvBlobStoreAccess,
     X: UserTask,
+    Z: NetCtl + WifiDiag + NetChangeNotif,
 {
     async fn run<T, N, Q, D>(
         &mut self,
@@ -535,7 +594,10 @@ where
 
         let mut mgr = WirelessMgr::new(&self.stack.network.networks, &net_ctl, &mut buf);
 
-        let net_ctl_s = NetCtlWithStatusImpl::new(&self.stack.network.net_state, &net_ctl);
+        let net_ctl_s = NetCtlWithStatusImpl::new(
+            &self.stack.network.net_state,
+            WirelessNetCtl::Operational(&net_ctl),
+        );
 
         let sys = self.stack.root_handler(
             &false,
@@ -588,14 +650,15 @@ where
     }
 }
 
-impl<'a, const B: usize, E, C, H, S, X> WifiCoexTask
-    for MatterStackWirelessTask<'a, B, wireless::Wifi, E, C, H, S, X>
+impl<'a, const B: usize, E, C, H, S, X, Z> WifiCoexTask
+    for MatterStackWirelessTask<'a, B, wireless::Wifi, E, C, H, S, X, Z>
 where
     E: Embedding,
     C: Crypto,
     H: DataModelHandler,
     S: KvBlobStoreAccess,
     X: UserTask,
+    Z: NetCtl + WifiDiag + NetChangeNotif,
 {
     async fn run<T, N, Q, D, G>(
         &mut self,
@@ -614,7 +677,10 @@ where
     {
         info!("Wifi and BLE drivers started");
 
-        let net_ctl_s = NetCtlWithStatusImpl::new(&self.stack.network.net_state, &net_ctl);
+        let net_ctl_s = NetCtlWithStatusImpl::new(
+            &self.stack.network.net_state,
+            WirelessNetCtl::Operational(&net_ctl),
+        );
 
         let sys = self.stack.root_handler(
             &true,


### PR DESCRIPTION
This optimization eradicates ~ 60-70KB of flash fatness for the non-concurrent commissioning flow via wireless, by avoiding the monomorphization of the whole handler chain.
